### PR TITLE
Remove status from expense

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -71,8 +71,7 @@ class ExpensesController < ApplicationController
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
-    # TODO: Add Expense target date
     def expense_params
-      params.require(:expense).permit(:name, :amount)
+      params.require(:expense).permit(:amount, :name, :strict_target_date, :target_date)
     end
 end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -71,7 +71,8 @@ class ExpensesController < ApplicationController
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
+    # TODO: Add Expense target date
     def expense_params
-      params.require(:expense).permit(:name, :amount, :status)
+      params.require(:expense).permit(:name, :amount)
     end
 end

--- a/app/helpers/expenses_helper.rb
+++ b/app/helpers/expenses_helper.rb
@@ -1,2 +1,5 @@
 module ExpensesHelper
+  def format_status(status)
+    status.titlecase
+  end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -6,7 +6,7 @@
 #  amount             :decimal(11, 2)
 #  name               :string
 #  strict_target_date :boolean          default(FALSE)
-#  target_date        :date
+#  target_date        :date             default(Sun, 08 Mar 2020)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  user_id            :integer

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -20,7 +20,20 @@ class Expense < ApplicationRecord
   belongs_to :user
   has_many :transactions
 
+  module Statuses
+    UNSTARTED = "unstarted"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    LATE = "late"
+  end
+
   def current_amount
     transactions.map(&:amount).sum
+  end
+
+  def status
+    return Statuses::LATE if Date.current > target_date && current_amount < amount
+    return Statuses::UNSTARTED if current_amount == 0
+    return current_amount < amount ? Statuses::IN_PROGRESS : Statuses::COMPLETED
   end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  amount             :decimal(11, 2)
 #  name               :string
-#  status             :integer
 #  strict_target_date :boolean          default(FALSE)
 #  target_date        :date
 #  created_at         :datetime         not null
@@ -20,8 +19,6 @@
 class Expense < ApplicationRecord
   belongs_to :user
   has_many :transactions
-
-  enum status: [:unstarted, :in_progress, :completed]
 
   def current_amount
     transactions.map(&:amount).sum

--- a/app/views/expenses/_expense.json.jbuilder
+++ b/app/views/expenses/_expense.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! expense, :id, :name, :amount, :status, :created_at, :updated_at
+json.extract! expense, :id, :name, :amount, :status, :target_date, :created_at, :updated_at
 json.url expense_url(expense, format: :json)

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -22,10 +22,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :status %>
-    <%= form.number_field :status %>
-
-  <div class="field">
     <%= form.label :target_date %>
     <%= form.text_field :target_date %>
   </div>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <td><%= expense.name %></td>
         <td><%= expense.amount %></td>
-        <td><%= expense.status %></td>
+        <td><%= format_status(expense.status) %></td>
         <td><%= expense.target_date %></td>
         <td><%= expense.strict_target_date ? "Yes" : "No" %></td>
         <td><%= link_to 'Show', expense %></td>

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -15,7 +15,7 @@
 
 <p>
   <strong>Status:</strong>
-  <%= @expense.status %>
+  <%= format_status(@expense.status) %>
 </p>
 
 <p>

--- a/db/migrate/20200122233819_add_target_date_to_expenses.rb
+++ b/db/migrate/20200122233819_add_target_date_to_expenses.rb
@@ -1,6 +1,6 @@
 class AddTargetDateToExpenses < ActiveRecord::Migration[6.0]
   def change
-    add_column :expenses, :target_date, :date
+    add_column :expenses, :target_date, :date, :default => Date.tomorrow
     add_column :expenses, :strict_target_date, :boolean, :default => false
   end
 end

--- a/db/migrate/20200124010848_remove_status_from_expenses.rb
+++ b/db/migrate/20200124010848_remove_status_from_expenses.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromExpenses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :expenses, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_010848) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
-    t.date "target_date"
+    t.date "target_date", default: "2020-03-08"
     t.boolean "strict_target_date", default: false
     t.index ["user_id"], name: "index_expenses_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_233819) do
+ActiveRecord::Schema.define(version: 2020_01_24_010848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define(version: 2020_01_22_233819) do
   create_table "expenses", force: :cascade do |t|
     t.string "name"
     t.decimal "amount", precision: 11, scale: 2
-    t.integer "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -6,7 +6,7 @@
 #  amount             :decimal(11, 2)
 #  name               :string
 #  strict_target_date :boolean          default(FALSE)
-#  target_date        :date
+#  target_date        :date             default(Sun, 08 Mar 2020)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  user_id            :integer

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  amount             :decimal(11, 2)
 #  name               :string
-#  status             :integer
 #  strict_target_date :boolean          default(FALSE)
 #  target_date        :date
 #  created_at         :datetime         not null
@@ -23,7 +22,6 @@ FactoryBot.define do
 
     f.name { "MyString" }
     f.amount { "9.99" }
-    f.status { :unstarted }
     f.target_date { Date.new(2020, 01, 22) }
     f.strict_target_date  { false }
 

--- a/spec/helpers/expenses_helper_spec.rb
+++ b/spec/helpers/expenses_helper_spec.rb
@@ -11,5 +11,12 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe ExpensesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "format_status" do
+    let(:status) { "a_hot-messOf-Stuff" }
+
+    it "formats the status correctly" do
+      formatted_status = format_status(status)
+      expect(formatted_status).to eq("A Hot Mess Of Stuff")
+    end
+  end
 end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -6,7 +6,7 @@
 #  amount             :decimal(11, 2)
 #  name               :string
 #  strict_target_date :boolean          default(FALSE)
-#  target_date        :date
+#  target_date        :date             default(Sun, 08 Mar 2020)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  user_id            :integer
@@ -40,6 +40,7 @@ RSpec.describe Expense, type: :model do
 
   describe "#status" do
     let(:current_date) { Date.new(2020, 01, 15) }
+
     before do
       allow(Date).to receive(:current).and_return(current_date)
       expense.amount = 100
@@ -47,6 +48,7 @@ RSpec.describe Expense, type: :model do
 
     context "when the due date is in the future" do
       let(:future_date) { Date.new(2020, 01, 24) }
+
       before do
         expense.target_date = future_date
       end
@@ -61,7 +63,7 @@ RSpec.describe Expense, type: :model do
         end
       end
 
-      context "and the expense is not completed" do
+      context "and the expense is started, but not completed" do
         before do
           allow(expense).to receive(:current_amount).and_return(10)
         end
@@ -84,6 +86,7 @@ RSpec.describe Expense, type: :model do
 
     context "when the due date is in the past" do
       let(:past_date) { Date.new(2020, 01, 01) }
+
       before do
         expense.target_date = past_date
       end
@@ -98,7 +101,7 @@ RSpec.describe Expense, type: :model do
         end
       end
 
-      context "and the expense hasn't been completed" do
+      context "and the expense is started, but hasn't been completed" do
         before do
           allow(expense).to receive(:current_amount).and_return(10)
         end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("unstarted")
+          expect(expense.status).to eq(Expense::Statuses::UNSTARTED)
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("in_progress")
+          expect(expense.status).to eq(Expense::Statuses::IN_PROGRESS)
         end
       end
 
@@ -77,7 +77,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("completed")
+          expect(expense.status).to eq(Expense::Statuses::COMPLETED)
         end
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("late")
+          expect(expense.status).to eq(Expense::Statuses::LATE)
         end
       end
 
@@ -104,7 +104,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("late")
+          expect(expense.status).to eq(Expense::Statuses::LATE)
         end
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Expense, type: :model do
         end
 
         it "returns the correct status" do
-          expect(expense.status).to eq("completed")
+          expect(expense.status).to eq(Expense::Statuses::COMPLETED)
         end
       end
     end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  amount             :decimal(11, 2)
 #  name               :string
-#  status             :integer
 #  strict_target_date :boolean          default(FALSE)
 #  target_date        :date
 #  created_at         :datetime         not null

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -37,4 +37,86 @@ RSpec.describe Expense, type: :model do
       expect(expense.current_amount).to eq(expected_amount)
     end
   end
+
+  describe "#status" do
+    let(:current_date) { Date.new(2020, 01, 15) }
+    before do
+      allow(Date).to receive(:current).and_return(current_date)
+      expense.amount = 100
+    end
+
+    context "when the due date is in the future" do
+      let(:future_date) { Date.new(2020, 01, 24) }
+      before do
+        expense.target_date = future_date
+      end
+
+      context "and the expense hasn't been started" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(0)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("unstarted")
+        end
+      end
+
+      context "and the expense is not completed" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(10)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("in_progress")
+        end
+      end
+
+      context "and the expense is paid in full" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(100)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("completed")
+        end
+      end
+    end
+
+    context "when the due date is in the past" do
+      let(:past_date) { Date.new(2020, 01, 01) }
+      before do
+        expense.target_date = past_date
+      end
+
+      context "and the expense hasn't been started" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(0)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("late")
+        end
+      end
+
+      context "and the expense hasn't been completed" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(10)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("late")
+        end
+      end
+
+      context "and the expense is paid in full" do
+        before do
+          allow(expense).to receive(:current_amount).and_return(100)
+        end
+
+        it "returns the correct status" do
+          expect(expense.status).to eq("completed")
+        end
+      end
+    end
+  end
 end

--- a/spec/views/expenses/edit.html.erb_spec.rb
+++ b/spec/views/expenses/edit.html.erb_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe "expenses/edit", type: :view do
       assert_select "input[name=?]", "expense[name]"
 
       assert_select "input[name=?]", "expense[amount]"
-
-      assert_select "input[name=?]", "expense[status]"
     end
   end
 end

--- a/spec/views/expenses/index.html.erb_spec.rb
+++ b/spec/views/expenses/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "expenses/index", type: :view do
     render
     assert_select "tr>td", :text => expenses.first.name, :count => 2
     assert_select "tr>td", :text => expenses.first.amount.to_s, :count => 2
-    assert_select "tr>td", :text => expenses.first.status.to_s, :count => 2
+    assert_select "tr>td", :text => format_status(expenses.first.status), :count => 2
     assert_select "tr>td", :text => expenses.first.target_date.to_s, :count => 2
     assert_select "tr>td", :text => "No", :count => 2
   end

--- a/spec/views/expenses/show.html.erb_spec.rb
+++ b/spec/views/expenses/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "expenses/show", type: :view do
     render
     expect(rendered).to match(expense.name)
     expect(rendered).to match(expense.amount.to_s)
-    expect(rendered).to match(expense.status.to_s)
+    expect(rendered).to match(format_status(expense.status))
     expect(rendered).to match(expense.target_date.to_s)
     expect(rendered).to match(expense.strict_target_date.to_s)
   end


### PR DESCRIPTION
Remove the `status` column from the `Expense` table, instead computing the status based on the target date